### PR TITLE
More Performant Templates Clonning

### DIFF
--- a/src/compiler/plugin.js
+++ b/src/compiler/plugin.js
@@ -27,7 +27,10 @@ const compileJSXPlugin = (babel, options) => {
         throw path.buildCodeFrameError("JSXFragment is not supported.");
       },
       Program(path) {
-        shared.set("templateFunctionName", path.scope.generateUidIdentifier("tmpl").name);
+        shared.set(
+          "templateFunctionName",
+          path.scope.generateUidIdentifier("template").name
+        );
         shared.set("firstElementChild", path.scope.generateUidIdentifier("fec").name);
         shared.set("nextElementSibling", path.scope.generateUidIdentifier("nes").name);
         shared.set("spreadFunctionName", path.scope.generateUidIdentifier("sprd").name);

--- a/src/compiler/shared.js
+++ b/src/compiler/shared.js
@@ -22,6 +22,8 @@ const shared = Osake({
   spreadFunctionName: "grim_$s",
   firstElementChild: "grim_$fec",
   nextElementSibling: "grim_$nes",
+
+  programPath: /** @type {babel.NodePath<babel.types.Program> | null} */ (null),
 });
 
 export { shared };

--- a/src/compiler/shared.js
+++ b/src/compiler/shared.js
@@ -24,6 +24,7 @@ const shared = Osake({
   nextElementSibling: "grim_$nes",
 
   programPath: /** @type {babel.NodePath<babel.types.Program> | null} */ (null),
+  sharedNodes: /** @type {Record<string, babel.types.VariableDeclaration>} */ ({}),
 });
 
 export { shared };

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -278,7 +278,7 @@ function JSXElement(path) {
 
     /**
      * We are lucky today, because this is just an _static_ html.
-     * TemplateLiteral does not have any expressions, so template could be extracled
+     * TemplateLiteral does not have any expressions, so template could be extracted
      */
     if (programPath && template.template.quasis.length === 1) {
       const current_raw = template.template.quasis[0].value.raw;
@@ -287,6 +287,9 @@ function JSXElement(path) {
       /** @type {babel.types.VariableDeclaration | null} */
       let decl = null;
 
+      /**
+       * If there are identical elements, we reuse them
+       */
       if (sharedNodes[current_raw]) {
         decl = sharedNodes[current_raw];
       } else {

--- a/src/compiler/transforms/post.js
+++ b/src/compiler/transforms/post.js
@@ -129,6 +129,8 @@ function post(file) {
   } else {
     produceImports();
   }
+
+  shared.set("sharedNodes", {});
 }
 
 export { post };

--- a/src/compiler/transforms/pre.js
+++ b/src/compiler/transforms/pre.js
@@ -52,6 +52,8 @@ const createPre = (options) => {
         }
       }
     }
+
+    shared.set("programPath", file.path);
   }
 
   return pre;

--- a/src/compiler/transforms/pre.js
+++ b/src/compiler/transforms/pre.js
@@ -54,6 +54,7 @@ const createPre = (options) => {
     }
 
     shared.set("programPath", file.path);
+    shared.set("sharedNodes", {});
   }
 
   return pre;

--- a/src/compiler/utils/create-iife.js
+++ b/src/compiler/utils/create-iife.js
@@ -1,0 +1,14 @@
+import { shared } from "../shared";
+
+/**
+ *
+ * @param  {...babel.types.Statement} body
+ * @returns
+ */
+const createIIFE = (...body) => {
+  const { types: t } = shared().babel;
+
+  return t.callExpression(t.arrowFunctionExpression([], t.blockStatement(body)), []);
+};
+
+export { createIIFE };

--- a/src/compiler/utils/index.js
+++ b/src/compiler/utils/index.js
@@ -7,4 +7,5 @@ export { getAttributeName } from "./get-attribute-name";
 export { jsxMemberExpressionToMemberExpression } from "./jsx-member-expression-to-member-expression";
 export { createTemplateLiteralBuilder } from "./template-literal-builder";
 export { isObject } from "./is-object";
+export { createIIFE } from "./create-iife";
 export * as constants from "./constants";

--- a/tests/dynamic attrs and child/expected.snapshot
+++ b/tests/dynamic attrs and child/expected.snapshot
@@ -1,10 +1,10 @@
-import { template as _tmpl } from "grim-jsx/runtime.js";
+import { template as _template } from "grim-jsx/runtime.js";
 import styles from './styles.module.css';
 
 const Paragraph = ({
   children
 }) => {
-  const p = _tmpl(`<p class="${styles.paragraph}">${children}</p>`);
+  const p = _template(`<p class="${styles.paragraph}">${children}</p>`);
 
   return p;
 };

--- a/tests/dynamic tag name/expected.snapshot
+++ b/tests/dynamic tag name/expected.snapshot
@@ -1,7 +1,7 @@
-import { template as _tmpl } from "grim-jsx/runtime.js";
+import { template as _template } from "grim-jsx/runtime.js";
 
 const As = props => {
-  const el = _tmpl(`<${props.as}></${props.as}>`);
+  const el = _template(`<${props.as}></${props.as}>`);
 
   return el;
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -63,12 +63,13 @@ async function main() {
             plugins: [
               [
                 compileJSXPlugin,
-                options !== null
-                  ? { ...defaultOptions, ...options }
-                  : defaultOptions,
+                options !== null ? { ...defaultOptions, ...options } : defaultOptions,
               ],
             ],
             babelrc: false,
+            browserslistConfigFile: false,
+            configFile: false,
+            highlightCode: false,
             comments: false,
             filename: entry.replaceAll(" ", "_"),
           });

--- a/tests/inline runtime/expected.snapshot
+++ b/tests/inline runtime/expected.snapshot
@@ -2,7 +2,7 @@ const _sprd = (props, attr) => {
   return Object.entries(props).map(([key, value]) => value == null ? '' : attr ? `${key}:${value};` : `${key}="${value}"`).join(" ");
 };
 
-const _tmpl = (html, isSVG) => {
+const _template = (html, isSVG) => {
   const t = document.createElement("template");
   t.innerHTML = html;
   let node = t.content.firstChild;
@@ -16,5 +16,5 @@ let cmp = props => {
     className,
     ...attrs
   } = props;
-  return _tmpl(`<div class="${className}" ${_sprd(attrs)}><p>${children}</p><button type="button">Inc</button></div>`);
+  return _template(`<div class="${className}" ${_sprd(attrs)}><p>${children}</p><button type="button">Inc</button></div>`);
 };

--- a/tests/object as attribute/expected.snapshot
+++ b/tests/object as attribute/expected.snapshot
@@ -1,11 +1,13 @@
-import { template as _tmpl, spread as _sprd } from "grim-jsx/runtime.js";
+import { template as _template, spread as _sprd } from "grim-jsx/runtime.js";
 
-const div = _tmpl(`<div style="color:red;">Hello</div>`);
+let _tmpl = _template(`<div style="color:red;">Hello</div>`);
+
+const div = _tmpl.cloneNode(true);
 
 let key = window.style_key;
 let value = window.style_value();
-const elements = [_tmpl(`<span style="${_sprd({
+const elements = [_template(`<span style="${_sprd({
   [key]: value
-}, true)}">Hello</span>`), _tmpl(`<span style="${_sprd({
+}, true)}">Hello</span>`), _template(`<span style="${_sprd({
   [window.style_key]: window.style_value()
 }, true)}">Hello</span>`)];

--- a/tests/simple node/code.snapshot
+++ b/tests/simple node/code.snapshot
@@ -1,1 +1,0 @@
-const div = <div style="color: red;">Hello</div>

--- a/tests/simple node/expected.snapshot
+++ b/tests/simple node/expected.snapshot
@@ -1,3 +1,0 @@
-import { template as _tmpl } from "grim-jsx/runtime.js";
-
-const div = _tmpl(`<div style="color: red;">Hello</div>`);

--- a/tests/spread/expected.snapshot
+++ b/tests/spread/expected.snapshot
@@ -1,3 +1,3 @@
-import { template as _tmpl, spread as _sprd } from "grim-jsx/runtime.js";
+import { template as _template, spread as _sprd } from "grim-jsx/runtime.js";
 
-const Component = props => _tmpl(`<div ${_sprd(props)}></div>`);
+const Component = props => _template(`<div ${_sprd(props)}></div>`);

--- a/tests/string mode/expected.snapshot
+++ b/tests/string mode/expected.snapshot
@@ -1,7 +1,10 @@
-import { template as _tmpl } from "grim-jsx/runtime.js";
+import { template as _template } from "grim-jsx/runtime.js";
+
+let _tmpl = _template(`<div></div>`);
+
 const people = ["Artem", "Ivan", "Arina", "Roman", "Kenzi"];
 let str = `<div><h1>Hello!</h1><ul>${people.map(person => `<li>${person}</li>`).join("")}</ul></div>`;
 
-const node = _tmpl(`<div></div>`);
+const node = _tmpl.cloneNode(true);
 
 str = `<div>It should be a string</div>`;

--- a/tests/svg/expected.snapshot
+++ b/tests/svg/expected.snapshot
@@ -1,7 +1,11 @@
-import { template as _tmpl } from "grim-jsx/runtime.js";
+import { template as _template } from "grim-jsx/runtime.js";
 
-const icon = _tmpl(`<svg width="24" height="24" fill="none" viewBox="0 0 24 24"></svg>`);
+let _tmpl2 = _template(`<svg><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18.25 12.25L5.75 12.25"></path></svg>`, true);
 
-const path = _tmpl(`<svg><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M18.25 12.25L5.75 12.25"></path></svg>`, true);
+let _tmpl = _template(`<svg width="24" height="24" fill="none" viewBox="0 0 24 24"></svg>`);
+
+const icon = _tmpl.cloneNode(true);
+
+const path = _tmpl2.cloneNode(true);
 
 icon.appendChild(path);

--- a/tests/using refs/expected.snapshot
+++ b/tests/using refs/expected.snapshot
@@ -1,18 +1,23 @@
-import { template as _tmpl, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/runtime.js";
+import { template as _template, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/runtime.js";
+
+let _tmpl2 = _template(`<footer><p>Copyright © 2069</p></footer>`);
+
+let _tmpl = _template(`<article><h1>Hello!</h1><p>Today we are going to find out something</p><button>Find out!</button></article>`);
+
 let button;
 
 const article = (() => {
-  const tmpl = _tmpl(`<article><h1>Hello!</h1><p>Today we are going to find out something</p><button>Find out!</button></article>`);
+  const _el = _tmpl.cloneNode(true);
 
-  button = tmpl[_fec][_nes][_nes];
-  return tmpl;
+  button = _el[_fec][_nes][_nes];
+  return _el;
 })();
 
 let foo;
 
 const footer = (() => {
-  const tmpl = _tmpl(`<footer><p>Copyright © 2069</p></footer>`);
+  const _el2 = _tmpl2.cloneNode(true);
 
-  foo = tmpl;
-  return tmpl;
+  foo = _el2;
+  return _el2;
 })();

--- a/tests/variables scoping/code.snapshot
+++ b/tests/variables scoping/code.snapshot
@@ -1,10 +1,10 @@
-let _tmpl = 'Noodles';
+let _template = 'Noodles';
 
 let eggs;
 
 const list = (
   <ul>
-    <li>{_tmpl}</li>
+    <li>{_template}</li>
     <li>Soup</li>
     <li>Rice</li>
     <li ref={eggs}>Eggs</li>

--- a/tests/variables scoping/expected.snapshot
+++ b/tests/variables scoping/expected.snapshot
@@ -1,10 +1,10 @@
-import { template as _tmpl2, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/runtime.js";
-let _tmpl = 'Noodles';
+import { template as _template2, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/runtime.js";
+let _template = 'Noodles';
 let eggs;
 
 const list = (() => {
-  const tmpl = _tmpl2(`<ul><li>${_tmpl}</li><li>Soup</li><li>Rice</li><li>Eggs</li></ul>`);
+  const _el = _template2(`<ul><li>${_template}</li><li>Soup</li><li>Rice</li><li>Eggs</li></ul>`);
 
-  eggs = tmpl[_fec][_nes][_nes][_nes];
-  return tmpl;
+  eggs = _el[_fec][_nes][_nes][_nes];
+  return _el;
 })();


### PR DESCRIPTION
As Ryan Carniato said [here](https://github.com/sveltejs/svelte/issues/3898#issuecomment-640389992), nodes should be cloned at the first place, because this is more performant.

Unfortunately, this doesn't always work with Grim, because the values are inserted into the template, and the output looks like this:
```jsx
let name = getName();
let el = template(`<div>Hello, ${name}!</div>`)
```
Therefore, only static solutions will be put at the beginning, and later will be copied via cloneNode.
This is how it looks in practice.

<details>
  <summary>Look at the code</summary>

### Input
  ```jsx
function Greet(name) {
    const el = (
      <div>
        <span class={styles.greeting}>{name}</span>
      </div>
    );

    const emoji = (
      <span>💀</span>
    );

    el.appendChild(emoji);

    return el;
}
  ```
### Before
```jsx
import { template as _tmpl } from "grim-jsx/dist/runtime.js";

function Greet(name) {
  const el = _tmpl(`<div><span class="${styles.greeting}">${name}</span></div>`);

  const emoji = _tmpl(`<span>💀</span>`);

  el.appendChild(emoji);
  return el;
}
```
### After
```jsx

import { template as _template } from "grim-jsx/dist/runtime.js";

let _tmpl = _template(`<span>💀</span>`);

function Greet(name) {
  const el = _template(`<div><span class="${styles.greeting}">${name}</span></div>`);

  const emoji = _tmpl.cloneNode(true);

  el.appendChild(emoji);
  return el;
}
```
</details>