### PR TITLE
Better Refs System

### DIFF
--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -152,6 +152,7 @@ function JSXElement(path) {
 
               /** @type {(babel.types.Identifier | babel.types.MemberExpression)[]} */
               let ph = [...current];
+              let path_changed = false;
 
               const keys = Object.keys(pathStore);
 
@@ -168,6 +169,7 @@ function JSXElement(path) {
                     ph = ph.slice(slc, ph.length);
                     ph = [nd, ...ph];
 
+                    path_changed = true;
                     break;
                   }
                 }
@@ -175,12 +177,11 @@ function JSXElement(path) {
 
               pathStore[curr_path] = expression;
 
-              const right =
-                ph.length === current.length
-                  ? current.length > 0
-                    ? createMemberExpression(templateName, ...current) || templateName
-                    : templateName
-                  : createMemberExpression(...ph) || templateName;
+              const right = path_changed
+                ? createMemberExpression(...ph) || templateName
+                : current.length > 0
+                ? createMemberExpression(templateName, ...current) || templateName
+                : templateName;
 
               for (const item of current) {
                 if (item.name === firstElementChild.name) {

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -82,7 +82,7 @@ function JSXElement(path) {
   };
 
   /** @type {Record<string, babel.types.Identifier | babel.types.MemberExpression>} */
-  const pathStore = {};
+  const pathsMap = {};
 
   /**
    * Try's to find the commend nodes with options
@@ -145,6 +145,7 @@ function JSXElement(path) {
             const { expression } = attr.value;
 
             if (t.isIdentifier(expression) || t.isMemberExpression(expression)) {
+              /** @type {string} */
               const curr_path =
                 current.length === 0
                   ? templateName.name
@@ -154,13 +155,16 @@ function JSXElement(path) {
               let ph = [...current];
               let path_changed = false;
 
-              const keys = Object.keys(pathStore);
+              const keys = Object.keys(pathsMap);
 
+              /**
+               * Longest paths comes to the end, so we iterate from the end
+               */
               for (let i = keys.length; i > 0; i--) {
                 const key = keys[i - 1];
 
                 if (curr_path.startsWith(key)) {
-                  const nd = pathStore[key];
+                  const nd = pathsMap[key];
 
                   if (key !== templateName.name) {
                     const str = curr_path.substring(0, key.length);
@@ -175,7 +179,7 @@ function JSXElement(path) {
                 }
               }
 
-              pathStore[curr_path] = expression;
+              pathsMap[curr_path] = expression;
 
               const right = path_changed
                 ? createMemberExpression(...ph) || templateName

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -81,6 +81,9 @@ function JSXElement(path) {
     }
   };
 
+  /** @type {Record<string, babel.types.Identifier | babel.types.MemberExpression>} */
+  const pathStore = {};
+
   /**
    * Try's to find the commend nodes with options
    */
@@ -142,10 +145,42 @@ function JSXElement(path) {
             const { expression } = attr.value;
 
             if (t.isIdentifier(expression) || t.isMemberExpression(expression)) {
+              const curr_path =
+                current.length === 0
+                  ? templateName.name
+                  : current.map((i) => i.name).join(".");
+
+              /** @type {(babel.types.Identifier | babel.types.MemberExpression)[]} */
+              let ph = [...current];
+
+              const keys = Object.keys(pathStore);
+
+              for (let i = keys.length; i > 0; i--) {
+                const key = keys[i - 1];
+
+                if (curr_path.startsWith(key)) {
+                  const nd = pathStore[key];
+
+                  if (key !== templateName.name) {
+                    const str = curr_path.substring(0, key.length);
+                    const slc = str.split(".").length;
+
+                    ph = ph.slice(slc, ph.length);
+                    ph = [nd, ...ph];
+
+                    break;
+                  }
+                }
+              }
+
+              pathStore[curr_path] = expression;
+
               const right =
-                current.length > 0
-                  ? createMemberExpression(templateName, ...current) || templateName
-                  : templateName;
+                ph.length === current.length
+                  ? current.length > 0
+                    ? createMemberExpression(templateName, ...current) || templateName
+                    : templateName
+                  : createMemberExpression(...ph) || templateName;
 
               for (const item of current) {
                 if (item.name === firstElementChild.name) {

--- a/src/compiler/utils/create-member-expression.js
+++ b/src/compiler/utils/create-member-expression.js
@@ -1,7 +1,7 @@
 import { shared } from "../shared";
 
 /**
- * @param {babel.types.Identifier[]} parts
+ * @param {(babel.types.Identifier | babel.types.MemberExpression)[]} parts
  * @returns {babel.types.MemberExpression | null}
  */
 const createMemberExpression = (...parts) => {

--- a/tests/quick refs/code.snapshot
+++ b/tests/quick refs/code.snapshot
@@ -1,0 +1,14 @@
+function App() {
+  let n0, n1, n2;
+
+  return (
+    <ul>
+      <li ref={n0}>0</li>
+      <li>1</li>
+      <li ref={n1}>2</li>
+      <li>3</li>
+      <li>4</li>
+      <li ref={n2}>5</li>
+    </ul>
+  )
+}

--- a/tests/quick refs/expected.snapshot
+++ b/tests/quick refs/expected.snapshot
@@ -8,7 +8,7 @@ function App() {
     let _el = _tmpl.cloneNode(true);
 
     n0 = _el[_fec];
-    n1 = _el[_fec][_nes][_nes];
+    n1 = n0[_nes][_nes];
     n2 = n1[_nes][_nes][_nes];
     return _el;
   })();

--- a/tests/quick refs/expected.snapshot
+++ b/tests/quick refs/expected.snapshot
@@ -1,0 +1,15 @@
+import { template as _template, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/runtime.js";
+
+let _tmpl = _template(`<ul><li>0</li><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>`);
+
+function App() {
+  let n0, n1, n2;
+  return (() => {
+    let _el = _tmpl.cloneNode(true);
+
+    n0 = _el[_fec];
+    n1 = _el[_fec][_nes][_nes];
+    n2 = n1[_nes][_nes][_nes];
+    return _el;
+  })();
+}


### PR DESCRIPTION
Grim uses a long chain of nextElementSibling and firstElementChild to get to the element. This is inherently a huge problem (in matter of bundle size), but additionally, this code:
```jsx
let n0, n1, n5;

(
    <ul>
      <li ref={n0}>0</li>
      <li ref={n1}>1</li>
      <li>2</li>
      <li>3</li>
      <li>4</li>
      <li ref={n5}>5</li>
    </ul>
);
```
Will be compiled into something like this:
```jsx
import { template as _template, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/dist/runtime.js";
let _tmpl = _template(`<ul><li>0</li><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>`);

let n0, n1, n5;

(() => {
  let _el = _tmpl.cloneNode(true);

  n0 = _el[_fec];
  n1 = _el[_fec][_nes];
  n5 = _el[_fec][_nes][_nes][_nes][_nes][_nes];
  return _el;
})();
```
So after this update, the same code will be compiled into this:
```jsx

import { template as _template, firstElementChild as _fec, nextElementSibling as _nes } from "grim-jsx/dist/runtime.js";
let _tmpl = _template(`<ul><li>0</li><li>1</li><li>2</li><li>3</li><li>4</li><li>5</li></ul>`);

let n0, n1, n5;

(() => {
  let _el = _tmpl.cloneNode(true);

  n0 = _el[_fec];
  n1 = n0[_nes];
  n5 = n1[_nes][_nes][_nes][_nes];
  return _el;
})();
```