### PR TITLE
Inline Attributes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,3 @@
 {
-  "printWidth": 90
+  "printWidth": 95
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grim-jsx",
-  "version": "0.15.4",
+  "version": "0.15.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "grim-jsx",
-      "version": "0.15.4",
+      "version": "0.15.5",
       "license": "MIT",
       "dependencies": {
         "@artemis69/im": "^0.2.0",

--- a/src/compiler/shared.js
+++ b/src/compiler/shared.js
@@ -9,7 +9,7 @@ const shared = Osake({
   enableStringMode: false,
 
   inlineRuntime: false,
-  runtime: /** @type {babel.types.Statement[]} */ ([]),
+  runtime: /** @type {import('@babel/core').types.Statement[]} */ ([]),
 
   inuse: {
     template: false,
@@ -23,8 +23,8 @@ const shared = Osake({
   firstElementChild: "grim_$fec",
   nextElementSibling: "grim_$nes",
 
-  programPath: /** @type {babel.NodePath<babel.types.Program> | null} */ (null),
-  sharedNodes: /** @type {Record<string, babel.types.VariableDeclaration>} */ ({}),
+  programPath: /** @type {babel.NodePath<import('@babel/core').types.Program> | null} */ (null),
+  sharedNodes: /** @type {Record<string, import('@babel/core').types.VariableDeclaration>} */ ({}),
 });
 
 export { shared };

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -14,7 +14,7 @@ import {
 } from "../utils";
 
 /**
- * @param {babel.NodePath<babel.types.JSXElement>} path
+ * @param {babel.NodePath<import('@babel/core').types.JSXElement>} path
  * @returns
  */
 function JSXElement(path) {
@@ -44,12 +44,12 @@ function JSXElement(path) {
 
   const root = node;
 
-  /** @type {babel.types.Identifier[]} */
+  /** @type {import('@babel/core').types.Identifier[]} */
   let current = [];
-  /** @type {null | babel.types.Identifier} */
+  /** @type {null | import('@babel/core').types.Identifier} */
   let type = firstElementChild;
 
-  /** @type {babel.types.ExpressionStatement[]} */
+  /** @type {import('@babel/core').types.ExpressionStatement[]} */
   const expressions = [];
 
   const template = createTemplateLiteralBuilder();
@@ -83,18 +83,18 @@ function JSXElement(path) {
     }
   };
 
-  /** @type {Record<string, babel.types.Identifier | babel.types.MemberExpression>} */
+  /** @type {Record<string, import('@babel/core').types.Identifier | import('@babel/core').types.MemberExpression>} */
   const pathsMap = {};
 
   /**
-   * @param {babel.types.Identifier | babel.types.MemberExpression} [expr]
+   * @param {import('@babel/core').types.Identifier | import('@babel/core').types.MemberExpression} [expr]
    */
   const generateNodeReference = (expr) => {
     /** @type {string} */
     const curr_path =
       current.length === 0 ? templateName.name : current.map((i) => i.name).join(".");
 
-    /** @type {(babel.types.Identifier | babel.types.MemberExpression)[]} */
+    /** @type {(import('@babel/core').types.Identifier | import('@babel/core').types.MemberExpression)[]} */
     let ph = [...current];
     let path_changed = false;
 
@@ -397,7 +397,7 @@ function JSXElement(path) {
       const current_raw = template.template.quasis[0].value.raw;
       const { sharedNodes } = shared();
 
-      /** @type {babel.types.VariableDeclaration | null} */
+      /** @type {import('@babel/core').types.VariableDeclaration | null} */
       let decl = null;
 
       /**

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -307,6 +307,11 @@ function JSXElement(path) {
 
                   if (!binding) return;
 
+                  /**
+                   * 'var' is appectable here because module exports get transformed to 'var'
+                   */
+                  if (binding.kind !== "var" && binding.kind !== "const") return;
+
                   const { path: bindingPath } = binding;
                   const { node: bindingNode } = bindingPath;
 
@@ -357,6 +362,11 @@ function JSXElement(path) {
                           mark();
                           break;
                         }
+
+                        /**
+                         * 'var' is also ok here because it also may be exported
+                         */
+                        if (binding.kind !== "var" && binding.kind !== "const") return;
 
                         const { path: bindingPath } = binding;
                         const { node: bindingNode } = bindingPath;

--- a/src/compiler/transforms/jsxElement.js
+++ b/src/compiler/transforms/jsxElement.js
@@ -305,7 +305,32 @@ function JSXElement(path) {
                 }
               } else if (t.isStringLiteral(expression)) {
                 template.push(insertAttrubute(name, expression.value));
+              } else if (t.isIdentifier(expression)) {
+                const binding = path.scope.getBinding(expression.name);
+
+                const write = () => {
+                  template.push(` ${name}="`);
+                  template.push(expression);
+                  template.push(`"`);
+                }
+
+                if (binding && (binding.kind === 'const')) {
+                  const { node } = binding.path;
+
+                  if (!t.isVariableDeclarator(node) || !t.isStringLiteral(node.init) || !t.isIdentifier(node.id)) {
+                    write();
+                    continue;
+                  }
+                  
+                  template.push(` ${name}="`)
+                  template.push(node.init.value)
+                  template.push(`"`);
+                } else {
+                  write()
+                }
               } else if (t.isExpression(expression)) {
+                
+
                 template.push(` ${name}="`);
                 template.push(expression);
                 template.push(`"`);

--- a/src/compiler/transforms/post.js
+++ b/src/compiler/transforms/post.js
@@ -27,7 +27,7 @@ function post(file) {
   } = shared();
 
   const produceImports = () => {
-    /** @type {babel.types.ImportSpecifier[]} */
+    /** @type {import('@babel/core').types.ImportSpecifier[]} */
     const importSpecifiers = [];
 
     if (inuse.template) {

--- a/src/compiler/utils/create-iife.js
+++ b/src/compiler/utils/create-iife.js
@@ -2,7 +2,7 @@ import { shared } from "../shared";
 
 /**
  *
- * @param  {...babel.types.Statement} body
+ * @param  {...import('@babel/core').types.Statement} body
  * @returns
  */
 const createIIFE = (...body) => {

--- a/src/compiler/utils/create-member-expression.js
+++ b/src/compiler/utils/create-member-expression.js
@@ -1,8 +1,8 @@
 import { shared } from "../shared";
 
 /**
- * @param {(babel.types.Identifier | babel.types.MemberExpression)[]} parts
- * @returns {babel.types.MemberExpression | null}
+ * @param {(import('@babel/core').types.Identifier | import('@babel/core').types.MemberExpression)[]} parts
+ * @returns {import('@babel/core').types.MemberExpression | null}
  */
 const createMemberExpression = (...parts) => {
   const { types: t } = shared().babel;

--- a/src/compiler/utils/get-attribute-name.js
+++ b/src/compiler/utils/get-attribute-name.js
@@ -1,7 +1,7 @@
 import { shared } from "../shared";
 
 /**
- * @param {babel.types.JSXAttribute} attr
+ * @param {import('@babel/core').types.JSXAttribute} attr
  */
 const getAttributeName = (attr) => {
   const { types: t } = shared().babel;

--- a/src/compiler/utils/get-jsx-element-name.js
+++ b/src/compiler/utils/get-jsx-element-name.js
@@ -1,7 +1,7 @@
 import { shared } from "../shared";
 
 /**
- * @param {babel.types.JSXIdentifier | babel.types.JSXMemberExpression | babel.types.JSXNamespacedName} node
+ * @param {import('@babel/core').types.JSXIdentifier | import('@babel/core').types.JSXMemberExpression | import('@babel/core').types.JSXNamespacedName} node
  */
 const getJSXElementName = (node) => {
   const { types: t } = shared().babel;

--- a/src/compiler/utils/get.js
+++ b/src/compiler/utils/get.js
@@ -1,0 +1,22 @@
+import { shared } from "../shared";
+
+/**
+ *
+ * @param {import('@babel/core').types.StringLiteral | import('@babel/core').types.Identifier} val
+ * @returns
+ */
+const get = (val) => {
+  const { types: t } = shared().babel;
+
+  let value = "";
+
+  if (t.isStringLiteral(val)) {
+    value = val.value;
+  } else if (t.isIdentifier(val)) {
+    value = val.name;
+  }
+
+  return value;
+};
+
+export { get };

--- a/src/compiler/utils/index.js
+++ b/src/compiler/utils/index.js
@@ -10,4 +10,6 @@ export { isObject } from "./is-object";
 export { createIIFE } from "./create-iife";
 export { is } from "./is";
 export { escape } from "./escape";
+export { trim } from "./trim-multiline";
+export { get } from "./get";
 export * as constants from "./constants";

--- a/src/compiler/utils/jsx-member-expression-to-member-expression.js
+++ b/src/compiler/utils/jsx-member-expression-to-member-expression.js
@@ -1,7 +1,7 @@
 import { shared } from "../shared";
 
 /**
- * @param {babel.types.JSXMemberExpression | babel.types.JSXIdentifier} expr
+ * @param {import('@babel/core').types.JSXMemberExpression | import('@babel/core').types.JSXIdentifier} expr
  */
 const jsxMemberExpressionToMemberExpression = (expr) => {
   const { types: t } = shared().babel;

--- a/src/compiler/utils/object-expression-to-attribute.js
+++ b/src/compiler/utils/object-expression-to-attribute.js
@@ -1,7 +1,7 @@
 import { shared } from "../shared";
 
 /**
- * @param {babel.types.ObjectProperty} p
+ * @param {import('@babel/core').types.ObjectProperty} p
  */
 const getKey = (p) => {
   const { types: t } = shared().babel;
@@ -24,7 +24,7 @@ const getKey = (p) => {
 };
 
 /**
- * @param {babel.types.ObjectProperty} p
+ * @param {import('@babel/core').types.ObjectProperty} p
  */
 const getValue = (p) => {
   const { types: t } = shared().babel;
@@ -39,7 +39,7 @@ const getValue = (p) => {
 };
 
 /**
- * @param {babel.types.ObjectExpression} ex
+ * @param {import('@babel/core').types.ObjectExpression} ex
  */
 const objectExpressionToAttribute = (ex) => {
   const { types: t } = shared().babel;

--- a/src/compiler/utils/template-literal-builder.js
+++ b/src/compiler/utils/template-literal-builder.js
@@ -17,7 +17,7 @@ const createTemplateLiteralBuilder = () => {
   };
 
   /**
-   * @param {string | babel.types.Expression | babel.types.JSXMemberExpression} arg
+   * @param {string | import('@babel/core').types.Expression | import('@babel/core').types.JSXMemberExpression} arg
    */
   const push = (arg) => {
     if (typeof arg === "string") {

--- a/src/compiler/utils/trim-multiline.js
+++ b/src/compiler/utils/trim-multiline.js
@@ -1,0 +1,48 @@
+import { escape } from "./escape";
+
+/**
+ * @param {string} value
+ * @returns {string | null}
+ */
+const trim = (value) => {
+  if (value.trim() === "") return null;
+
+  const splitted = value.split("\n");
+
+  let text = "";
+
+  let i = 0;
+
+  while (i < splitted.length) {
+    const line = splitted[i];
+
+    let str = escape(line.trim());
+
+    /**
+     *  `     I am formatting` -> `I am formatting`
+     *  ` I am not`            -> ` I am not`
+     *  `I just retarded     ` -> `I just retarded`
+     *  `I am not `            -> `I am not `
+     */
+
+    if (line[0] === " " && line[1] !== " ") {
+      str = " " + str;
+    }
+
+    let len = line.length;
+
+    if (line[len - 1] === " " && line[len - 2] !== " ") {
+      str += " ";
+    }
+
+    if (str.trim() !== "") {
+      text += i > 1 ? " " + str : str;
+    }
+
+    i++;
+  }
+
+  return text;
+};
+
+export { trim };

--- a/tests/inline const values/code.snapshot
+++ b/tests/inline const values/code.snapshot
@@ -1,0 +1,7 @@
+const className = "red_uglyhash";
+
+function App() {
+  return (
+    <div class={className}>Content</div>
+  )
+}

--- a/tests/inline const values/expected.snapshot
+++ b/tests/inline const values/expected.snapshot
@@ -1,0 +1,9 @@
+import { template as _template } from "grim-jsx/runtime.js";
+
+let _tmpl = _template(`<div class="red_uglyhash">Content</div>`);
+
+const className = "red_uglyhash";
+
+function App() {
+  return _tmpl.cloneNode(true);
+}

--- a/tests/inline object/code.snapshot
+++ b/tests/inline object/code.snapshot
@@ -1,0 +1,18 @@
+// styles.module.css
+
+const header = "_header_hash";
+
+var styles = {
+  header: header,
+  "title__great": "_title__great_hash",
+};
+
+// App.jsx
+
+function App() {
+  return (
+    <div class={styles.header}>
+      <h1 class={styles.title__great}>Hello World</h1>
+    </div>
+  )
+}

--- a/tests/inline object/expected.snapshot
+++ b/tests/inline object/expected.snapshot
@@ -1,0 +1,13 @@
+import { template as _template } from "grim-jsx/runtime.js";
+
+let _tmpl = _template(`<div class="_header_hash"><h1 class="_title__great_hash">Hello World</h1></div>`);
+
+const header = "_header_hash";
+var styles = {
+  header: header,
+  "title__great": "_title__great_hash"
+};
+
+function App() {
+  return _tmpl.cloneNode(true);
+}


### PR DESCRIPTION
Now it is possible to inline some constant values.

Code:
```jsx
const className = "red_uglyhash";

function App() {
  return (
    <div class={className}>Content</div>
  )
}
```
Compiled:
```jsx
import { template as _template } from "grim-jsx/runtime.js";

let _tmpl = _template(`<div class="red_uglyhash">Content</div>`);

const className = "red_uglyhash";

function App() {
  return _tmpl.cloneNode(true);
}
```

`const` string cannot be changed, so it can be inlined.

But there may not only be a primitive values, like

Code:
```jsx
// styles.module.css

const header = "_header_hash";

var styles = {
  header: header,
  "title__great": "_title__great_hash",
};

// App.jsx

function App() {
  return (
    <div class={styles.header}>
      <h1 class={styles.title__great}>Hello World</h1>
    </div>
  )
}
```
Compiled:
```jsx
import { template as _template } from "grim-jsx/runtime.js";

let _tmpl = _template(`<div class="_header_hash"><h1 class="_title__great_hash">Hello World</h1></div>`);

const header = "_header_hash";

var styles = {
  header: header,
  "title__great": "_title__great_hash"
};

function App() {
  return _tmpl.cloneNode(true);
}
```

Object's are mutable no matter it is declared as `const` or `let`, or `var`, however we will try to inline it.